### PR TITLE
fix: track firebase.js to fix CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,4 @@ ui-debug.log*
 .firebase/
 .firebaserc/
 src/common/config.js
-src/common/firebase.js
 package-lock.json

--- a/src/common/firebase.js
+++ b/src/common/firebase.js
@@ -1,0 +1,23 @@
+import { initializeApp, getApps } from 'firebase/app'
+import { getAuth } from 'firebase/auth'
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore'
+
+const config = {
+  apiKey: process.env.VUE_APP_FIREBASE_API_KEY,
+  authDomain: process.env.VUE_APP_FIREBASE_AUTH_DOMAIN,
+  databaseURL: process.env.VUE_APP_FIREBASE_DATABASE_URL,
+  projectId: process.env.VUE_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.VUE_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.VUE_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VUE_APP_FIREBASE_APP_ID,
+  measurementId: process.env.VUE_APP_FIREBASE_MEASUREMENT_ID
+}
+
+const app = getApps().length ? getApps()[0] : initializeApp(config)
+
+export const auth = getAuth(app)
+export const db = getFirestore(app)
+
+if (window.location.hostname === 'localhost' && process.env.VUE_APP_USE_EMULATOR === 'true') {
+  connectFirestoreEmulator(db, 'localhost', 8081)
+}


### PR DESCRIPTION
## Summary

- `src/common/firebase.js` was listed in `.gitignore`, causing CI to fail with `Module not found: Can't resolve './firebase'`
- The file contains **no hardcoded secrets** — it only references `process.env.VUE_APP_FIREBASE_*` env vars already set as GitHub secrets
- Removed it from `.gitignore` and committed the file so the build succeeds in GitHub Actions

## Test plan

- [ ] Verify CI workflow passes after merge (`Deploy to GitHub Pages` action)
- [ ] Confirm no secrets are exposed (file uses only `process.env.*` references)
- [ ] Check GitHub Pages deploys successfully to `/vue-hotel/`